### PR TITLE
Basvs audio hack

### DIFF
--- a/components/audio_stream/i2s_stream.c
+++ b/components/audio_stream/i2s_stream.c
@@ -75,8 +75,8 @@ static esp_err_t i2s_mono_fix(int bits, uint8_t *sbuff, uint32_t len)
 
 // hacker hotel badge quick&dirty volume hack.
 unsigned int i2s_stream_volume = 8;
-unsigned int i2s_fixup_word_0 = 0x01;
-unsigned int i2s_fixup_word_1 = 0x10;
+unsigned int i2s_mixer_ctl_0 = 0x00000080;
+unsigned int i2s_mixer_ctl_1 = 0x00800000;
 static esp_err_t i2s_volume_fix(int bits, uint8_t *sbuff, uint32_t len)
 {
     if (i2s_stream_volume == 0) {
@@ -86,46 +86,64 @@ static esp_err_t i2s_volume_fix(int bits, uint8_t *sbuff, uint32_t len)
     }
 
 	// fixup words
+	int32_t w0_0 = i2s_mixer_ctl_0 & 0xff;
+	if (w0_0 > 128) w0_0 = 128;
+	if (i2s_mixer_ctl_0 & 0x100) w0_0 = -w0_0;
+	int32_t w0_1 = (i2s_mixer_ctl_0 >> 16) & 0xff;
+	if (w0_1 > 128) w0_1 = 128;
+	if (i2s_mixer_ctl_0 & 0x1000000) w0_1 = -w0_1;
+
+	int32_t w1_0 = i2s_mixer_ctl_1 & 0xff;
+	if (w1_0 > 128) w1_0 = 128;
+	if (i2s_mixer_ctl_1 & 0x100) w1_0 = -w1_0;
+	int32_t w1_1 = (i2s_mixer_ctl_1 >> 16) & 0xff;
+	if (w1_1 > 128) w1_1 = 128;
+	if (i2s_mixer_ctl_1 & 0x1000000) w1_1 = -w1_1;
+
+	// add volume
+	if (i2s_stream_volume < 128) {
+		w0_0 = (w0_0 * (int32_t) i2s_stream_volume) >> 7;
+		w0_1 = (w0_1 * (int32_t) i2s_stream_volume) >> 7;
+		w1_0 = (w1_0 * (int32_t) i2s_stream_volume) >> 7;
+		w1_1 = (w1_1 * (int32_t) i2s_stream_volume) >> 7;
+	}
+
     if (bits == 16) {
         int16_t *temp_buf = (int16_t *)sbuff;
         for (int i = 0; i < len / 4; i++) {
             int32_t word_0 = temp_buf[i*2+0];
             int32_t word_1 = temp_buf[i*2+1];
+            // drop the lowest 8 bits.
 			int32_t new_word_0 = 0;
-			if (i2s_fixup_word_0 & 0x01) new_word_0 += word_0;
-			if (i2s_fixup_word_0 & 0x02) new_word_0 -= word_0;
-			if (i2s_fixup_word_0 & 0x10) new_word_0 += word_1;
-			if (i2s_fixup_word_0 & 0x20) new_word_0 -= word_1;
+            new_word_0 += (word_0 * w0_0) >> 8;
+            new_word_0 += (word_1 * w0_1) >> 8;
 			int32_t new_word_1 = 0;
-			if (i2s_fixup_word_1 & 0x01) new_word_1 += word_0;
-			if (i2s_fixup_word_1 & 0x02) new_word_1 -= word_0;
-			if (i2s_fixup_word_1 & 0x10) new_word_1 += word_1;
-			if (i2s_fixup_word_1 & 0x20) new_word_1 -= word_1;
-            // drop the lowest bits.
-            temp_buf[i*2+0] = new_word_0 >> 1;
-            temp_buf[i*2+1] = new_word_1 >> 1;
+            new_word_1 += (word_0 * w1_0) >> 8;
+            new_word_1 += (word_1 * w1_1) >> 8;
+            temp_buf[i*2+0] = new_word_0;
+            temp_buf[i*2+1] = new_word_1;
         }
     } else if (bits == 32) {
         int32_t *temp_buf = (int32_t *)sbuff;
         for (int i = 0; i < len / 8; i++) {
-            // drop the lowest bits.
-            int32_t word_0 = temp_buf[i*2+0] >> 1;
-            int32_t word_1 = temp_buf[i*2+1] >> 1;
+            // drop the lowest 8 bits.
+            int32_t word_0 = temp_buf[i*2+0] >> 8;
+            int32_t word_1 = temp_buf[i*2+1] >> 8;
 			int32_t new_word_0 = 0;
-			if (i2s_fixup_word_0 & 0x01) new_word_0 += word_0;
-			if (i2s_fixup_word_0 & 0x02) new_word_0 -= word_0;
-			if (i2s_fixup_word_0 & 0x10) new_word_0 += word_1;
-			if (i2s_fixup_word_0 & 0x20) new_word_0 -= word_1;
+            new_word_0 += (word_0 * w0_0) >> 8;
+            new_word_0 += (word_1 * w0_1) >> 8;
 			int32_t new_word_1 = 0;
-			if (i2s_fixup_word_1 & 0x01) new_word_1 += word_0;
-			if (i2s_fixup_word_1 & 0x02) new_word_1 -= word_0;
-			if (i2s_fixup_word_1 & 0x10) new_word_1 += word_1;
-			if (i2s_fixup_word_1 & 0x20) new_word_1 -= word_1;
+            new_word_1 += (word_0 * w1_0) >> 8;
+            new_word_1 += (word_1 * w1_1) >> 8;
             temp_buf[i*2+0] = new_word_0;
             temp_buf[i*2+1] = new_word_1;
         }
+    } else {
+        ESP_LOGE(TAG, "%s %dbits is not supported", __func__, bits);
+        return ESP_FAIL;
 	}
 
+/*
     if (i2s_stream_volume >= 128) {
         // max sound
         return ESP_OK;
@@ -141,7 +159,7 @@ static esp_err_t i2s_volume_fix(int bits, uint8_t *sbuff, uint32_t len)
     } else if (bits == 32) {
         int32_t *temp_buf = (int32_t *)sbuff;
         for (int i = 0; i < len / 4; i++) {
-            // drop the lower 7 bits.
+            // drop the lowest 7 bits.
             int32_t temp_box = temp_buf[i] >> 7;
             temp_box = temp_box * (int32_t) i2s_stream_volume;
             temp_buf[i] = temp_box;
@@ -150,6 +168,7 @@ static esp_err_t i2s_volume_fix(int bits, uint8_t *sbuff, uint32_t len)
         ESP_LOGE(TAG, "%s %dbits is not supported", __func__, bits);
         return ESP_FAIL;
     }
+*/
 
     return ESP_OK;
 }
@@ -333,7 +352,7 @@ esp_err_t i2s_stream_set_clk(audio_element_handle_t i2s_stream, int rate, int bi
     return err;
 }
 
-audio_element_handle_t i2s_stream_init(i2s_stream_cfg_t *config)
+audio_element_handle_t i2s_stream_init(const i2s_stream_cfg_t *config)
 {
     audio_element_cfg_t cfg = DEFAULT_AUDIO_ELEMENT_CONFIG();
     audio_element_handle_t el;

--- a/components/audio_stream/include/i2s_stream.h
+++ b/components/audio_stream/include/i2s_stream.h
@@ -102,6 +102,8 @@ typedef struct {
 
 // hacker hotel badge quick&dirty volume hack.
 extern unsigned int i2s_stream_volume;
+extern unsigned int i2s_fixup_word_0;
+extern unsigned int i2s_fixup_word_1;
 
 /**
  * @brief      Create a handle to an Audio Element to stream data from I2S to another Element

--- a/components/audio_stream/include/i2s_stream.h
+++ b/components/audio_stream/include/i2s_stream.h
@@ -102,8 +102,8 @@ typedef struct {
 
 // hacker hotel badge quick&dirty volume hack.
 extern unsigned int i2s_stream_volume;
-extern unsigned int i2s_fixup_word_0;
-extern unsigned int i2s_fixup_word_1;
+extern unsigned int i2s_mixer_ctl_0;
+extern unsigned int i2s_mixer_ctl_1;
 
 /**
  * @brief      Create a handle to an Audio Element to stream data from I2S to another Element
@@ -115,7 +115,7 @@ extern unsigned int i2s_fixup_word_1;
  *
  * @return     The Audio Element handle
  */
-audio_element_handle_t i2s_stream_init(i2s_stream_cfg_t *config);
+audio_element_handle_t i2s_stream_init(const i2s_stream_cfg_t *config);
 
 /**
  * @brief      Setup clock for I2S Stream, this function is only used with handle created by `i2s_stream_init`


### PR DESCRIPTION
This enables mixing and reversing of channels . . 

```python
audio.mixer_ctl_0(-128, 0)
audio.mixer_ctl_1(128, 128)
```

To "fix" our reversed jack hardware issue . . 